### PR TITLE
line 28 in generate_mapping.py changing export_all to simulate_best

### DIFF
--- a/mocasin/tasks/generate_mapping.py
+++ b/mocasin/tasks/generate_mapping.py
@@ -25,7 +25,7 @@ def generate_mapping(cfg):
 
     **Hydra Parameters**:
         * **mapper:** the mapper (mapping algorithm) to be used.
-        * **export_all:** a flag indicating whether all mappings should be
+        * **simulate_best:** a flag indicating whether all mappings should be
           exported. If ``false`` only the best mapping will be exported.
         * **graph:** the input dataflow graph. The task expects a configuration dict
           that can be instantiated to a :class:`~mocasin.common.graph.DataflowGraph`


### PR DESCRIPTION
While executing the generate_mapping command, the  "simulate_best" flag is not recognized, instead, I used simulate-best=``true`` and it worked. So I changed line 28 in the file generate_mapping.py from export_all to simulate_best. 